### PR TITLE
Backport infra & tooling improvements from our main service

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+**/bin/
+**/obj/
+**/.vs/
+**/.idea/
+**/.vscode/
+**/node_modules/
+.git
+.gitignore
+README.md
+TEMPLATE-SETUP.md
+docs/
+tests/

--- a/.editorconfig
+++ b/.editorconfig
@@ -307,6 +307,10 @@ dotnet_diagnostic.IDE0200.severity = warning
 dotnet_style_allow_multiple_blank_lines_experimental = false
 dotnet_diagnostic.IDE2000.severity = warning
 
+# EF Core auto-generated migration files — do not enforce style rules
+[**/Migrations/*.cs]
+generated_code = true
+
 [{eng/tools/**.cs,**/{test,testassets,samples,Samples,perf,scripts,stress}/**.cs}]
 # CA1018: Mark attributes with AttributeUsageAttribute
 dotnet_diagnostic.CA1018.severity = suggestion

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  test-backend:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v4
+        with:
+          dotnet-version: "10.0.x"
+      - run: dotnet restore
+      - run: dotnet build -c Release --no-restore
+      # The integration tests spin up Postgres via Testcontainers and migrate on
+      # startup, so they need an EF migration to create the schema. This template
+      # ships no migration, so the step below is disabled by default. Once you have
+      # added your first migration (see README "Apply initial migration"), uncomment
+      # it to run the full suite in CI:
+      # - run: dotnet test -c Release --no-build
+
+  vulnerability-scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      # Run grype directly via its Docker image, pinned by sha256 digest. This avoids
+      # mutable tag aliases in the supply chain (checkout is pinned by commit SHA;
+      # grype by image digest — content-addressed, immutable). Digest below is
+      # anchore/grype:v0.111.0. To upgrade: pull the new tag, copy its `Digest:` value
+      # here, update this comment.
+      - name: Run grype vulnerability scan
+        run: |
+          docker run --rm \
+            -v "$GITHUB_WORKSPACE:/workspace:ro" \
+            -w /workspace \
+            anchore/grype@sha256:af9f30d1de4ecfbbcd2b674371e8df787879e16832af8ab81551b0bf1ec0ad5b \
+            dir:. \
+            --fail-on high \
+            --only-fixed \
+            -o table
+
+  docker-build:
+    needs: [test-backend]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        with:
+          context: .
+          file: src/WebApi/Dockerfile
+          push: false

--- a/.gitignore
+++ b/.gitignore
@@ -569,5 +569,3 @@ FodyWeavers.xsd
 
 ### VisualStudio Patch ###
 # Additional files built by Visual Studio
-
-.pre-commit-trivy-cache

--- a/.gitignore
+++ b/.gitignore
@@ -569,3 +569,13 @@ FodyWeavers.xsd
 
 ### VisualStudio Patch ###
 # Additional files built by Visual Studio
+
+# dotnet build sometimes creates directories with literal backslashes on Linux
+bin\\*
+
+# JetBrains IDE
+.idea/
+
+# Secrets
+.env
+.envrc

--- a/.idea/.idea.WebApiTemplate/.idea/.name
+++ b/.idea/.idea.WebApiTemplate/.idea/.name
@@ -1,1 +1,0 @@
-WebApiTemplate

--- a/.idea/.idea.WebApiTemplate/.idea/encodings.xml
+++ b/.idea/.idea.WebApiTemplate/.idea/encodings.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="Encoding" addBOMForNewFiles="with BOM under Windows, with no BOM otherwise" />
-</project>

--- a/.idea/.idea.WebApiTemplate/.idea/indexLayout.xml
+++ b/.idea/.idea.WebApiTemplate/.idea/indexLayout.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="UserContentModel">
-    <attachedFolders />
-    <explicitIncludes />
-    <explicitExcludes />
-  </component>
-</project>

--- a/.idea/.idea.WebApiTemplate/.idea/projectSettingsUpdater.xml
+++ b/.idea/.idea.WebApiTemplate/.idea/projectSettingsUpdater.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="RiderProjectSettingsUpdater">
-    <option name="singleClickDiffPreview" value="1" />
-    <option name="unhandledExceptionsIgnoreList" value="1" />
-    <option name="vcsConfiguration" value="3" />
-  </component>
-</project>

--- a/.idea/.idea.WebApiTemplate/.idea/vcs.xml
+++ b/.idea/.idea.WebApiTemplate/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="" vcs="Git" />
-  </component>
-</project>

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,25 @@
 ---
 repos:
-  - repo: https://github.com/thoughtworks/talisman
-    rev: "v1.37.0"
+  # General file hygiene
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c # v6.0.0
     hooks:
-      - id: talisman-commit
-        entry: cmd --githook pre-commit
+      - id: no-commit-to-branch
+        args: [--branch, main]
+      - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-added-large-files
+        args: [--maxkb=500]
+
+  # Secret scanning
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: 83d9cd684c87d95d656c1458ef04895a7f1cbd8e # v8.30.1
+    hooks:
+      - id: gitleaks
   - repo: local
     hooks:
       # dotnet tools

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
         description: Install the .NET tools listed at .config/dotnet-tools.json.
       - id: csharpier
         name: Run CSharpier on C# files
-        entry: dotnet tool run dotnet-csharpier
+        entry: dotnet csharpier format
         language: system
         types:
           - c#

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,13 +7,6 @@ repos:
         entry: cmd --githook pre-commit
   - repo: local
     hooks:
-      - id: trivy-fs
-        name: trivyfs
-        entry: aquasec/trivy fs --scanners vuln,misconfig --cache-dir /src/.pre-commit-trivy-cache --exit-code 0 ./
-        language: docker_image
-        pass_filenames: false
-        always_run: true
-        verbose: true
       # dotnet tools
       - id: dotnet-tool-restore
         name: Install .NET tools

--- a/.talismanrc
+++ b/.talismanrc
@@ -1,8 +1,0 @@
-fileignoreconfig:
-- filename: src/WebApiTemplate.Application/QueryHandlerCachingDecorator.cs
-  checksum: ec7a355dd536358b6b67ff15df3af6918344e5fc404d3ad07d7dd096ea841af7
-- filename: test/WebApiTemplate.IntegrationTests/AppWebApplicationFactory.cs
-  checksum: 3e27ba162115530609565834ee7eb4d091b3fda0b94813571410730f334a997d
-- filename: test/WebApiTemplate.IntegrationTests/Constants.cs
-  checksum: bc1f6aa439357b6713f1ec0de88155ea744cc2aa27ac9e7bf71e5a8d8e2a747b
-version: ""

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,4 +8,9 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
+
+  <!-- Workaround: .NET 10 SDK emits a **/*.resx glob that fails the build when no resx files exist -->
+  <ItemGroup>
+    <EmbeddedResource Remove="**/*.resx" />
+  </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,25 +8,25 @@
     <GlobalPackageReference Include="IDisposableAnalyzers" Version="4.0.8" />
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.3">
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
-    <PackageVersion Include="Npgsql.DependencyInjection" Version="10.0.1" />
-    <PackageVersion Include="SimpleInjector" Version="5.5.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Npgsql.DependencyInjection" Version="10.0.3" />
+    <PackageVersion Include="SimpleInjector" Version="5.5.2" />
     <PackageVersion Include="SimpleInjector.Integration.AspNetCore.Mvc" Version="5.5.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.1.4" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.0" />
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
     <PackageVersion Include="HumbleMediator" Version="1.1.1" />
-    <PackageVersion Include="Dapper" Version="2.1.35" />
+    <PackageVersion Include="Dapper" Version="2.1.79" />
     <PackageVersion Include="Dapper.Contrib" Version="2.0.78" />
     <PackageVersion Include="EFCore.NamingConventions" Version="10.0.1" />
-    <PackageVersion Include="Npgsql" Version="10.0.1" />
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
+    <PackageVersion Include="Npgsql" Version="10.0.3" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
     <PackageVersion Include="Serilog" Version="4.3.1" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />

--- a/README.md
+++ b/README.md
@@ -63,10 +63,15 @@ When you have the project ready, it's time to create the initial migration using
 Here's an example command using the default solution name, if you changed it you would have to adapt it accordingly:
 
 ```sh
-dotnet ef migrations add --project ./src/Infrastructure/Infrastructure.csproj --context AppDbContext --startup-project ./src/Api/Api.csproj InitialMigration
+dotnet ef migrations add --project ./src/Infrastructure/Infrastructure.csproj --context AppDbContext --startup-project ./src/WebApi/WebApi.csproj InitialMigration
 ```
 
 The above migration is applied automatically during startup in the dev environment.
+
+> **Enable tests in CI:** the integration tests create their schema by migrating on
+> startup, so they need at least one migration. Once you've added the migration above,
+> uncomment the `dotnet test` step in [.github/workflows/ci.yml](.github/workflows/ci.yml)
+> to run the full suite on every pull request.
 
 ### 3. Start the application
 The default API endpoints should be testable from the [Swagger UI](http://localhost:5000/swagger/index.html).

--- a/README.md
+++ b/README.md
@@ -77,3 +77,8 @@ The above migration is applied automatically during startup in the dev environme
 The default API endpoints should be testable from the [Swagger UI](http://localhost:5000/swagger/index.html).
 
 Enjoy!
+
+### 4. CI/CD
+This template ships a CI workflow at [.github/workflows/ci.yml](.github/workflows/ci.yml) that runs on every pull request: it restores and builds the solution, scans dependencies with [grype](https://github.com/anchore/grype), and builds the Docker image. The `dotnet test` step is commented out until you add your first migration (see step 2).
+
+It does **not** ship a release/deployment pipeline — deploy targets vary too much to template usefully. You need to create your own: typically, on push to `main`, build and push the image from [src/WebApi/Dockerfile](src/WebApi/Dockerfile) to your container registry, then trigger a deploy to your host.

--- a/src/WebApi/Dockerfile
+++ b/src/WebApi/Dockerfile
@@ -1,26 +1,30 @@
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /build
 
-# copy csproj and restore as distinct layers for caching
-COPY src/Api/Api.csproj ./src/Api/Api.csproj
-COPY src/Core/Core.csproj ./src/Core/Core.csproj
-COPY src/Application/Application.csproj ./src/Application/Application.csproj
-COPY src/Infrastructure/Infrastructure.csproj ./src/Infrastructure/Infrastructure.csproj
+# copy csproj and props files, then restore as distinct layers for caching
 COPY Directory.Build.props .
+COPY Directory.Packages.props .
+COPY src/Core/Core.csproj ./src/Core/
+COPY src/Application/Application.csproj ./src/Application/
+COPY src/Infrastructure/Infrastructure.csproj ./src/Infrastructure/
+COPY src/WebApi/WebApi.csproj ./src/WebApi/
 RUN dotnet restore -r linux-x64 "./src/WebApi/WebApi.csproj"
 
-# copy and publish app and libraries
-COPY src/Api/ ./src/Api/
+# copy source and publish
 COPY src/Core/ ./src/Core/
 COPY src/Application/ ./src/Application/
 COPY src/Infrastructure/ ./src/Infrastructure/
+COPY src/WebApi/ ./src/WebApi/
 RUN dotnet publish -c Release --no-self-contained -r linux-x64 -o /app "./src/WebApi/WebApi.csproj"
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/aspnet:10.0
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 ENV ASPNETCORE_URLS=http://+:5000
 EXPOSE 5000
 WORKDIR /app
 COPY --from=build /app .
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD curl -sf http://localhost:5000/health || exit 1
 USER app
 ENTRYPOINT ["dotnet", "WebApiTemplate.WebApi.dll"]

--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -48,16 +48,46 @@ try
 
     Action<IServiceProvider, DbContextOptionsBuilder> dbConfigure = (sp, options) =>
         options.UseNpgsql(sp.GetRequiredService<NpgsqlDataSource>()).UseSnakeCaseNamingConvention();
-    builder.Services.AddDbContext<AppDbContext>(dbConfigure, ServiceLifetime.Singleton);
-    builder.Services.AddPooledDbContextFactory<AppDbContext>(dbConfigure);
+
+    // AppDbContext is registered Scoped (the EF Core default) — never Singleton. A
+    // DbContext is not thread-safe, so a singleton would be shared across concurrent
+    // requests (e.g. the /health AddDbContextCheck below). The unit-of-work write path
+    // does not use this registration directly: it creates a fresh context per unit of
+    // work from the factory below.
+    //
+    // The factory is Scoped (not pooled). A pooled factory is itself a singleton, so it
+    // would have to resolve EF's now-Scoped IDbContextOptionsConfiguration<AppDbContext>
+    // from the root provider, which throws. Keeping the context and its factory both
+    // Scoped aligns the option-configuration lifetimes.
+    builder.Services.AddDbContext<AppDbContext>(dbConfigure);
+    builder.Services.AddDbContextFactory<AppDbContext>(dbConfigure, ServiceLifetime.Scoped);
     builder.Services.AddDistributedMemoryCache();
+
+    // Required by SimpleInjector's ASP.NET Core integration to resolve cross-wired
+    // *scoped* services (e.g. IDbContextFactory<AppDbContext>) from the active request's
+    // IServiceProvider. Without it those resolve from the root provider and trip MS-DI
+    // scope validation.
+    builder.Services.AddHttpContextAccessor();
 
     // SimpleInjector
     var container = Container;
-    container.Options.DefaultLifestyle = Lifestyle.Singleton;
+    // Scoped is the correct default lifestyle for a per-request web app: handlers,
+    // repositories and the unit-of-work factory resolve once per request instead of as
+    // process-wide singletons that would capture state across requests. The AspNetCore
+    // integration opens an async scope per request (and a verification scope for
+    // container.Verify()).
+    container.Options.DefaultLifestyle = Lifestyle.Scoped;
     builder.Services.AddSimpleInjector(
         container,
-        options => options.AddAspNetCore().AddControllerActivation()
+        options =>
+        {
+            options.AddAspNetCore().AddControllerActivation();
+
+            // IDbContextFactory<AppDbContext> is Scoped — cross-wire it explicitly so
+            // SimpleInjector resolves it from the active request scope. Auto cross-wiring
+            // resolves it from the root provider, which trips MS-DI's scope validation.
+            options.CrossWire<IDbContextFactory<AppDbContext>>();
+        }
     );
 
     container.Register<ICustomerReadRepository, CustomerReadRepository>();
@@ -104,8 +134,10 @@ try
     // to make sure that migrations are applied as a separate deploy step to prevent data corruption.
     if (app.Environment.IsDevelopment())
     {
-        var dbContextFactory = app.Services.GetRequiredService<IDbContextFactory<AppDbContext>>();
-        var dbContext = await dbContextFactory.CreateDbContextAsync();
+        // AppDbContext is Scoped, so it must be resolved from a scope rather than the
+        // root provider.
+        await using var migrationScope = app.Services.CreateAsyncScope();
+        var dbContext = migrationScope.ServiceProvider.GetRequiredService<AppDbContext>();
         if (dbContext.Database.IsRelational())
         {
             // It will throw if the db is not relational

--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using FluentValidation;
 using HumbleMediator;
+using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.EntityFrameworkCore;
 using Npgsql;
 using Serilog;
@@ -34,7 +35,30 @@ try
 
     // swagger
     builder.Services.AddEndpointsApiExplorer();
-    builder.Services.AddSwaggerGen();
+    builder.Services.AddSwaggerGen(options =>
+    {
+        // Infer required/nullable from C# nullability annotations (NRT): `string Name`
+        // becomes required + non-nullable, `string? Foo` stays optional + nullable. Gives
+        // the generated TypeScript client accurate types.
+        options.SupportNonNullableReferenceTypes();
+        options.NonNullableReferenceTypesAsRequired();
+
+        // Derive operationId from controller + action for clean client generation,
+        // e.g. CustomersController.GetById -> "Customers_GetById".
+        options.CustomOperationIds(apiDesc =>
+            apiDesc.ActionDescriptor is ControllerActionDescriptor action
+                ? $"{action.ControllerName}_{action.ActionName}"
+                : null
+        );
+
+        // Surface the XML doc comments (/// ...) in the OpenAPI document. Every project
+        // sets GenerateDocumentationFile=true, so include each app assembly's XML from the
+        // output directory.
+        foreach (var xml in Directory.GetFiles(AppContext.BaseDirectory, "WebApiTemplate.*.xml"))
+        {
+            options.IncludeXmlComments(xml, includeControllerXmlComments: true);
+        }
+    });
 
     builder.Services.AddHealthChecks().AddDbContextCheck<AppDbContext>();
 

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -3,18 +3,18 @@
   <ItemGroup>
     <GlobalPackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
     <GlobalPackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <GlobalPackageReference Include="coverlet.collector" Version="8.0.0" />
+    <GlobalPackageReference Include="coverlet.collector" Version="10.0.1" />
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
     <PackageVersion Include="Respawn" Version="7.0.0" />
-    <PackageVersion Include="Testcontainers" Version="4.10.0" />
-    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.10.0" />
+    <PackageVersion Include="Testcontainers" Version="4.12.0" />
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.12.0" />
   </ItemGroup>
 </Project>

--- a/tests/IntegrationTests/AppWebApplicationFactory.cs
+++ b/tests/IntegrationTests/AppWebApplicationFactory.cs
@@ -34,9 +34,15 @@ public class AppWebApplicationFactory : WebApplicationFactory<Program>, IAsyncLi
     {
         await _dbContainer.StartAsync();
 
-        var contextFactory = this.Services.GetRequiredService<IDbContextFactory<AppDbContext>>();
-        await using var context = await contextFactory.CreateDbContextAsync();
-        await using var connection = context.Database.GetDbConnection();
+        // Force host startup so Program.cs runs MigrateAsync in Development mode.
+        _ = this.Services;
+
+        // Resolve the Respawn connection from the singleton NpgsqlDataSource — the
+        // DbContext and its factory are Scoped and cannot be resolved from the root
+        // provider here.
+        await using var connection = this
+            .Services.GetRequiredService<NpgsqlDataSource>()
+            .CreateConnection();
         await connection.OpenAsync();
         _respawner = await Respawner.CreateAsync(
             connection,
@@ -70,22 +76,32 @@ public class AppWebApplicationFactory : WebApplicationFactory<Program>, IAsyncLi
             }
 
             services.AddNpgsqlDataSource(_dbContainer.GetConnectionString());
-            services.AddPooledDbContextFactory<AppDbContext>(
-                (sp, options) =>
-                    options
-                        .UseNpgsql(sp.GetRequiredService<NpgsqlDataSource>())
-                        .UseSnakeCaseNamingConvention()
-            );
+
+            Action<IServiceProvider, DbContextOptionsBuilder> dbConfigure = (sp, options) =>
+                options
+                    .UseNpgsql(sp.GetRequiredService<NpgsqlDataSource>())
+                    .UseSnakeCaseNamingConvention();
+
+            services.AddDbContext<AppDbContext>(dbConfigure);
+            services.AddDbContextFactory<AppDbContext>(dbConfigure, ServiceLifetime.Scoped);
 
             Program.Container.Options.AllowOverridingRegistrations = true;
         });
     }
 
+    /// <summary>
+    /// Creates a DI scope for resolving scoped services (e.g. IDbContextFactory) outside
+    /// of an HTTP request — used by tests to seed and assert against the database. The
+    /// DbContext and its factory are Scoped, so they cannot be resolved directly from the
+    /// root provider (<see cref="WebApplicationFactory{TEntryPoint}.Services"/>).
+    /// </summary>
+    public AsyncServiceScope CreateScope() => Services.CreateAsyncScope();
+
     public async Task ResetDatabase()
     {
-        var contextFactory = this.Services.GetRequiredService<IDbContextFactory<AppDbContext>>();
-        await using var context = await contextFactory.CreateDbContextAsync();
-        await using var connection = context.Database.GetDbConnection();
+        await using var connection = this
+            .Services.GetRequiredService<NpgsqlDataSource>()
+            .CreateConnection();
         await connection.OpenAsync();
         await _respawner.ResetAsync(connection);
     }

--- a/tests/IntegrationTests/Customers/Controllers/CreateTests.cs
+++ b/tests/IntegrationTests/Customers/Controllers/CreateTests.cs
@@ -16,11 +16,12 @@ public class CreateTests(AppWebApplicationFactory factory) : BaseTestClass(facto
 
         using var client = _factory.CreateClient();
         var request = new CreateCustomerRequest();
-        using var response = await client.PostAsJsonAsync($"/api/customers", request);
+        using var response = await client.PostAsJsonAsync($"/api/v1/customers", request);
 
         response.StatusCode.Should().Be(HttpStatusCode.Created);
 
-        var contextFactory = _factory.Services.GetRequiredService<
+        await using var scope = _factory.CreateScope();
+        var contextFactory = scope.ServiceProvider.GetRequiredService<
             IDbContextFactory<AppDbContext>
         >();
         await using var context = await contextFactory.CreateDbContextAsync();

--- a/tests/IntegrationTests/Customers/Controllers/DeleteTests.cs
+++ b/tests/IntegrationTests/Customers/Controllers/DeleteTests.cs
@@ -14,7 +14,8 @@ public class DeleteTests(AppWebApplicationFactory factory) : BaseTestClass(facto
         await _factory.ResetDatabase();
         const int id = 1278;
 
-        var contextFactory = _factory.Services.GetRequiredService<
+        await using var scope = _factory.CreateScope();
+        var contextFactory = scope.ServiceProvider.GetRequiredService<
             IDbContextFactory<AppDbContext>
         >();
         await using var context = await contextFactory.CreateDbContextAsync();
@@ -22,7 +23,7 @@ public class DeleteTests(AppWebApplicationFactory factory) : BaseTestClass(facto
         await context.SaveChangesAsync();
 
         using var client = _factory.CreateClient();
-        using var response = await client.DeleteAsync($"/api/customers/{id}");
+        using var response = await client.DeleteAsync($"/api/v1/customers/{id}");
 
         response.StatusCode.Should().Be(HttpStatusCode.NoContent);
         var allCustomers = await context.Customers.ToListAsync();

--- a/tests/IntegrationTests/Customers/Controllers/GetByIdTests.cs
+++ b/tests/IntegrationTests/Customers/Controllers/GetByIdTests.cs
@@ -14,7 +14,8 @@ public class GetByIdTests(AppWebApplicationFactory factory) : BaseTestClass(fact
         await _factory.ResetDatabase();
         const int id = 23;
 
-        var contextFactory = _factory.Services.GetRequiredService<
+        await using var scope = _factory.CreateScope();
+        var contextFactory = scope.ServiceProvider.GetRequiredService<
             IDbContextFactory<AppDbContext>
         >();
         await using var context = await contextFactory.CreateDbContextAsync();
@@ -22,7 +23,7 @@ public class GetByIdTests(AppWebApplicationFactory factory) : BaseTestClass(fact
         await context.SaveChangesAsync();
 
         using var client = _factory.CreateClient();
-        using var response = await client.GetAsync($"/api/customers/{id}");
+        using var response = await client.GetAsync($"/api/v1/customers/{id}");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
@@ -38,7 +39,7 @@ public class GetByIdTests(AppWebApplicationFactory factory) : BaseTestClass(fact
         const int id = 483930;
 
         using var client = _factory.CreateClient();
-        using var response = await client.GetAsync($"/api/customers/{id}");
+        using var response = await client.GetAsync($"/api/v1/customers/{id}");
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }


### PR DESCRIPTION
Backports infrastructure/tooling improvements from our main service, and fixes several pre-existing template bugs found along the way.

## Changes
- **refactor(persistence): scoped EF registration** — `AppDbContext` + factory `Singleton → Scoped`, SimpleInjector `DefaultLifestyle = Scoped`, explicit `CrossWire<IDbContextFactory>` + `AddHttpContextAccessor`, migrate-in-scope. (A singleton `DbContext` is an EF Core anti-pattern.)
- **build:** .NET 10 `**/*.resx` workaround + exempt `**/Migrations/*.cs` from style rules.
- **build:** fix the csharpier pre-commit hook (csharpier 1.x renamed the command).
- **feat(swagger):** `IncludeXmlComments` (surface `///` docs) + `CustomOperationIds` + NRT-aware schemas.
- **build(deps):** upgrade to latest stable (EF 10.0.8, Npgsql 10.0.3, Swashbuckle 10.2.0, Testcontainers 4.12, …).
- **ci:** remove trivy from pre-commit (ran unpinned `:latest`; never ships in the app).
- **fix(docker):** working Dockerfile (the old one used the pre-rename `src/Api` paths and never copied `Directory.Packages.props`) + `.dockerignore`.
- **ci:** SHA-pinned GitHub Actions (build + grype + docker-build) — the repo had none.
- **ci:** align pre-commit hooks — add file-hygiene hooks (SHA-pinned), switch talisman → gitleaks (talisman false-positived on the SHA-pinned hook revs).
- **chore:** gitignore hygiene — ignore `bin\\*`, `.env`, `.idea`; untrack committed `.idea`.
- Pre-existing bug fixes in passing: test URLs → `/api/v1`, README migration command path.

## Validation
Build green; unit + Testcontainers integration tests pass (validated with a temporary `InitialCreate` migration); `docker build` succeeds; all pre-commit hooks pass.

## Follow-ups (not in this PR)
- **Initial EF migration:** the template ships none, so integration tests can't run in CI out of the box. The CI `dotnet test` step is commented out, with README instructions to enable it after adding the first migration.
- **EF paged-list read repository** (`PagedResult<T>`, list endpoint, drop Dapper) — separate PR.