### PR TITLE
feat: EF-based list/pagination read repository + entities as classes

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,8 +22,6 @@
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.0" />
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
     <PackageVersion Include="HumbleMediator" Version="1.1.1" />
-    <PackageVersion Include="Dapper" Version="2.1.79" />
-    <PackageVersion Include="Dapper.Contrib" Version="2.0.78" />
     <PackageVersion Include="EFCore.NamingConventions" Version="10.0.1" />
     <PackageVersion Include="Npgsql" Version="10.0.3" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ I found implementations of similar samples/templates to often be overly complica
 
 ## Features
 - Based on .NET 10 to have access to the latest features
-- Simplified Startup.cs hosting model
+- Minimal hosting model (top-level statements in `Program.cs`)
 - [CQRS](https://docs.microsoft.com/en-us/azure/architecture/patterns/cqrs) with full separation between Read and Write repositories
 - Simple [Mediator](https://en.wikipedia.org/wiki/Mediator_pattern) abstraction for CQRS and implementation relying on the chosen Dependency Injection container (see [HumbleMediator](https://github.com/undrivendev/HumbleMediator))
 - Project structure following [Clean Architecture](https://blog.cleancoder.com/uncle-bob/2012/08/13/the-clean-architecture.html) principles
@@ -27,10 +27,12 @@ I found implementations of similar samples/templates to often be overly complica
   - Caching: [QueryHandlerCachingDecorator](src/Application/QueryHandlerCachingDecorator.cs)
   - Validation: [CommandHandlerValidationDecorator](src/Application/Validation/CommandHandlerValidationDecorator.cs) and [QueryHandlerValidationDecorator](src/Application/Validation/QueryHandlerValidationDecorator.cs)
 - Structured logging using the standard [MEL](https://github.com/dotnet/runtime/tree/main/src/libraries/Microsoft.Extensions.Logging.Abstractions) interface with the open-source [Serilog](https://serilog.net/) logging library implementation
-- Cache-friendly [Dockerfile](src/WebApi/Dockerfile)
+- Cache-friendly [Dockerfile](src/WebApi/Dockerfile) with a `/health` container HEALTHCHECK
 - Expressive testing using [xUnit](https://xunit.net/) and [AwesomeAssertions](https://github.com/AwesomeAssertions/AwesomeAssertions)
 - Integration testing using real database implementation with [Testcontainers](https://dotnet.testcontainers.org/)
 - [Central Package Management](https://learn.microsoft.com/en-us/nuget/consume-packages/Central-Package-Management)
+- Continuous integration via [GitHub Actions](.github/workflows/ci.yml): build, dependency vulnerability scan with [grype](https://github.com/anchore/grype), and Docker image build
+- [pre-commit](https://pre-commit.com/) hooks: C# formatting with [CSharpier](https://csharpier.com/), secret scanning with [gitleaks](https://github.com/gitleaks/gitleaks), and general file-hygiene checks
 
 ## Usage
 ### 1. Bootstrap your project

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ I found implementations of similar samples/templates to often be overly complica
 - [CQRS](https://docs.microsoft.com/en-us/azure/architecture/patterns/cqrs) with full separation between Read and Write repositories
 - Simple [Mediator](https://en.wikipedia.org/wiki/Mediator_pattern) abstraction for CQRS and implementation relying on the chosen Dependency Injection container (see [HumbleMediator](https://github.com/undrivendev/HumbleMediator))
 - Project structure following [Clean Architecture](https://blog.cleancoder.com/uncle-bob/2012/08/13/the-clean-architecture.html) principles
-- Read repositories based on [Dapper](https://dapperlib.github.io/Dapper/) (Raw SQL) for fastest query execution times
-- Write repositories based on [Entity Framework Core](https://github.com/dotnet/efcore) to take advantage on the built-in change tracking mechanism
+- Read and write repositories based on [Entity Framework Core](https://github.com/dotnet/efcore), behind tech-agnostic `IReadRepository`/`IWriteRepository` interfaces — `Application`/`Core` never reference EF, so a repository can be backed by [Dapper](https://dapperlib.github.io/Dapper/) or raw ADO.NET without touching business logic
+- Read repositories ship built-in pagination, sorting, and free-text search scaffolding (`PagedResult<T>`, `ListAsync`)
 - [PostgreSQL](https://www.postgresql.org/) open source database as data store (easily replaceable with any Entity Framework-supported data stores)
 - Database configured to use snake_case naming convention via [EFCore.NamingConventions](https://github.com/efcore/EFCore.NamingConventions)
 - Migrations handled by Entity Framework and automatically applied during startup (in dev environment)
@@ -27,8 +27,8 @@ I found implementations of similar samples/templates to often be overly complica
   - Caching: [QueryHandlerCachingDecorator](src/Application/QueryHandlerCachingDecorator.cs)
   - Validation: [CommandHandlerValidationDecorator](src/Application/Validation/CommandHandlerValidationDecorator.cs) and [QueryHandlerValidationDecorator](src/Application/Validation/QueryHandlerValidationDecorator.cs)
 - Structured logging using the standard [MEL](https://github.com/dotnet/runtime/tree/main/src/libraries/Microsoft.Extensions.Logging.Abstractions) interface with the open-source [Serilog](https://serilog.net/) logging library implementation
-- Cache-friendly [Dockerfile](src/Api/Dockerfile)
-- Expressive testing using [xUnit](https://xunit.net/) and [FluentAssertions](https://fluentassertions.com/)
+- Cache-friendly [Dockerfile](src/WebApi/Dockerfile)
+- Expressive testing using [xUnit](https://xunit.net/) and [AwesomeAssertions](https://github.com/AwesomeAssertions/AwesomeAssertions)
 - Integration testing using real database implementation with [Testcontainers](https://dotnet.testcontainers.org/)
 - [Central Package Management](https://learn.microsoft.com/en-us/nuget/consume-packages/Central-Package-Management)
 

--- a/src/Application/Customers/Queries/ListCustomersQuery.cs
+++ b/src/Application/Customers/Queries/ListCustomersQuery.cs
@@ -1,0 +1,19 @@
+using HumbleMediator;
+using WebApiTemplate.Core.Common;
+using WebApiTemplate.Core.Customers;
+
+namespace WebApiTemplate.Application.Customers.Queries;
+
+/// <summary>
+/// Query to list customers with search, sorting, and pagination.
+/// </summary>
+/// <param name="Search">Free-text search term.</param>
+/// <param name="OrderBy">Comma-separated sort fields; prefix with <c>-</c> for descending.</param>
+/// <param name="Offset">Zero-based offset.</param>
+/// <param name="Limit">Maximum number of items to return.</param>
+public sealed record ListCustomersQuery(
+    string? Search,
+    string? OrderBy,
+    int Offset = 0,
+    int Limit = 25
+) : IQuery<PagedResult<Customer>>;

--- a/src/Application/Customers/Queries/ListCustomersQueryHandler.cs
+++ b/src/Application/Customers/Queries/ListCustomersQueryHandler.cs
@@ -1,0 +1,19 @@
+using HumbleMediator;
+using WebApiTemplate.Core.Common;
+using WebApiTemplate.Core.Customers;
+
+namespace WebApiTemplate.Application.Customers.Queries;
+
+/// <summary>
+/// Handles listing customers with search, sort, and pagination.
+/// </summary>
+/// <param name="readRepository">The customer read repository.</param>
+public class ListCustomersQueryHandler(ICustomerReadRepository readRepository)
+    : IQueryHandler<ListCustomersQuery, PagedResult<Customer>>
+{
+    /// <inheritdoc />
+    public Task<PagedResult<Customer>> Handle(
+        ListCustomersQuery query,
+        CancellationToken cancellationToken = default
+    ) => readRepository.ListAsync(query.Search, query.OrderBy, query.Offset, query.Limit);
+}

--- a/src/Application/Customers/Queries/ListCustomersQueryValidator.cs
+++ b/src/Application/Customers/Queries/ListCustomersQueryValidator.cs
@@ -1,0 +1,45 @@
+using FluentValidation;
+
+namespace WebApiTemplate.Application.Customers.Queries;
+
+/// <summary>
+/// Validates the <see cref="ListCustomersQuery"/> parameters.
+/// </summary>
+public sealed class ListCustomersQueryValidator : AbstractValidator<ListCustomersQuery>
+{
+    // Sortable fields for Customer. Add your entity's fields here, and the matching mapping
+    // in CustomerReadRepository.GetSortSelector.
+    private static readonly HashSet<string> AllowedSortFields = new(
+        StringComparer.OrdinalIgnoreCase
+    )
+    {
+        "id",
+    };
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ListCustomersQueryValidator"/> class.
+    /// </summary>
+    public ListCustomersQueryValidator()
+    {
+        RuleFor(x => x.Offset).GreaterThanOrEqualTo(0);
+        RuleFor(x => x.Limit).InclusiveBetween(1, 100);
+
+        RuleFor(x => x.OrderBy)
+            .Must(BeValidSortExpression!)
+            .When(x => !string.IsNullOrWhiteSpace(x.OrderBy))
+            .WithMessage("Invalid sort field. Allowed: id");
+    }
+
+    private static bool BeValidSortExpression(string orderBy)
+    {
+        var fields = orderBy.Split(
+            ',',
+            StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries
+        );
+        return fields.All(f =>
+        {
+            var fieldName = f.StartsWith('-') ? f[1..] : f;
+            return AllowedSortFields.Contains(fieldName);
+        });
+    }
+}

--- a/src/Core/BaseEntity.cs
+++ b/src/Core/BaseEntity.cs
@@ -3,5 +3,10 @@ namespace WebApiTemplate.Core;
 /// <summary>
 /// Base class for all domain entities.
 /// </summary>
-/// <param name="Id">The id of the entity.</param>
-public abstract record BaseEntity(int? Id);
+public abstract class BaseEntity
+{
+    /// <summary>
+    /// Gets or sets the id of the entity. Null until the entity has been persisted.
+    /// </summary>
+    public int? Id { get; set; }
+}

--- a/src/Core/Common/PagedResult.cs
+++ b/src/Core/Common/PagedResult.cs
@@ -1,0 +1,7 @@
+namespace WebApiTemplate.Core.Common;
+
+/// <summary>
+/// Generic paginated result containing the page of items and the total row count.
+/// </summary>
+/// <typeparam name="T">The item type.</typeparam>
+public sealed record PagedResult<T>(IReadOnlyList<T> Items, int Total);

--- a/src/Core/Customers/Customer.cs
+++ b/src/Core/Customers/Customer.cs
@@ -3,5 +3,4 @@ namespace WebApiTemplate.Core.Customers;
 /// <summary>
 /// Customer entity.
 /// </summary>
-/// <param name="Id"><inheritdoc /></param>
-public record Customer(int? Id) : BaseEntity(Id);
+public class Customer : BaseEntity { }

--- a/src/Core/IReadRepository.cs
+++ b/src/Core/IReadRepository.cs
@@ -1,4 +1,6 @@
-﻿namespace WebApiTemplate.Core;
+using WebApiTemplate.Core.Common;
+
+namespace WebApiTemplate.Core;
 
 /// <summary>
 /// Base interface for read repositories.
@@ -8,9 +10,22 @@ public interface IReadRepository<T>
     where T : BaseEntity
 {
     /// <summary>
-    /// Get the entity by its id.
+    /// Gets the entity by its id. When <paramref name="uow"/> is provided the entity is read
+    /// through its DbContext (so it is change-tracked); otherwise a fresh, stateless DbContext
+    /// is used.
     /// </summary>
     /// <param name="id">The id of the entity to get.</param>
+    /// <param name="uow">Optional unit of work for tracked reads.</param>
     /// <returns>The entity, if found, otherwise null.</returns>
-    public Task<T?> GetById(int id);
+    public Task<T?> GetById(int id, IUnitOfWork? uow = null);
+
+    /// <summary>
+    /// Lists entities with free-text search, sorting, and pagination.
+    /// </summary>
+    /// <param name="search">Free-text search term (entity-specific fields).</param>
+    /// <param name="orderBy">Comma-separated sort fields; prefix a field with <c>-</c> for descending.</param>
+    /// <param name="offset">Zero-based offset.</param>
+    /// <param name="limit">Maximum number of items to return.</param>
+    /// <returns>A paged result with the items and the total count.</returns>
+    public Task<PagedResult<T>> ListAsync(string? search, string? orderBy, int offset, int limit);
 }

--- a/src/Infrastructure/Customers/CustomerReadRepository.cs
+++ b/src/Infrastructure/Customers/CustomerReadRepository.cs
@@ -1,18 +1,33 @@
-﻿using System.Data.Common;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore;
 using WebApiTemplate.Core.Customers;
 using WebApiTemplate.Infrastructure.Persistence;
 
 namespace WebApiTemplate.Infrastructure.Customers;
 
 /// <summary>
-/// Repository for reading <see cref="Customer"/> entities.
+/// Repository for reading <see cref="Customer"/> entities. Supplies the entity-specific
+/// search and sort behaviour on top of <see cref="ReadRepositoryBase{T}"/>.
 /// </summary>
-public class CustomerReadRepository : ReadRepositoryBase<Customer>, ICustomerReadRepository
+/// <param name="dbContextFactory">The DbContext factory.</param>
+public class CustomerReadRepository(IDbContextFactory<AppDbContext> dbContextFactory)
+    : ReadRepositoryBase<Customer>(dbContextFactory),
+        ICustomerReadRepository
 {
-    /// <summary>
-    /// Initializes a new instance of the <see cref="CustomerReadRepository"/> class.
-    /// </summary>
-    /// <param name="db"></param>
-    public CustomerReadRepository(DbDataSource db)
-        : base(db) { }
+    // Customer only carries an Id in this template. For a real entity, override ApplySearch
+    // to declare which fields are searchable, e.g.:
+    //
+    //   protected override IQueryable<Customer> ApplySearch(IQueryable<Customer> query, string search)
+    //   {
+    //       var pattern = $"%{search}%";
+    //       return query.Where(c => EF.Functions.ILike(c.Name, pattern));
+    //   }
+
+    /// <inheritdoc />
+    protected override Expression<Func<Customer, object?>>? GetSortSelector(string fieldName) =>
+        fieldName.ToLowerInvariant() switch
+        {
+            "id" => c => c.Id,
+            _ => null,
+        };
 }

--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -6,8 +6,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Dapper" />
-      <PackageReference Include="Dapper.Contrib" />
       <PackageReference Include="EFCore.NamingConventions" />
       <PackageReference Include="Microsoft.EntityFrameworkCore" />
       <PackageReference Include="Npgsql" />

--- a/src/Infrastructure/Persistence/ReadRepositoryBase.cs
+++ b/src/Infrastructure/Persistence/ReadRepositoryBase.cs
@@ -1,25 +1,122 @@
-using System.Data.Common;
-using Dapper.Contrib.Extensions;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore;
 using WebApiTemplate.Core;
+using WebApiTemplate.Core.Common;
 
 namespace WebApiTemplate.Infrastructure.Persistence;
 
 /// <summary>
-/// Base class for read repositories.
+/// Base class for read repositories, backed by EF Core via <see cref="IDbContextFactory{TContext}"/>.
+/// Provides pagination/sorting/search boilerplate; subclasses supply entity-specific search
+/// predicates and sort-field mappings by overriding <see cref="ApplySearch"/>,
+/// <see cref="GetSortSelector"/>, and <see cref="ApplyDefaultSort"/>.
 /// </summary>
-/// <param name="db">The database data source.</param>
+/// <param name="dbContextFactory">The DbContext factory.</param>
 /// <typeparam name="T">The entity type.</typeparam>
-public abstract class ReadRepositoryBase<T>(DbDataSource db) : IReadRepository<T>
+public abstract class ReadRepositoryBase<T>(IDbContextFactory<AppDbContext> dbContextFactory)
+    : IReadRepository<T>
     where T : BaseEntity
 {
     /// <summary>
-    /// Gets the entity by its id.
+    /// The DbContext factory, available to subclasses for custom queries.
     /// </summary>
-    /// <param name="id">The id of the entity to get.</param>
-    /// <returns>The entity with the specified id.</returns>
-    public virtual async Task<T?> GetById(int id)
+    protected IDbContextFactory<AppDbContext> DbContextFactory { get; } = dbContextFactory;
+
+    /// <inheritdoc />
+    public virtual async Task<T?> GetById(int id, IUnitOfWork? uow = null)
     {
-        await using var conn = await db.OpenConnectionAsync();
-        return await conn.GetAsync<T>(id);
+        if (uow is not null)
+        {
+            var dbContext = ((UnitOfWork)uow).DbContext;
+            return await dbContext.Set<T>().FirstOrDefaultAsync(e => e.Id == id);
+        }
+
+        await using var ctx = await DbContextFactory.CreateDbContextAsync();
+        return await ctx.Set<T>().FirstOrDefaultAsync(e => e.Id == id);
+    }
+
+    /// <inheritdoc />
+    public virtual async Task<PagedResult<T>> ListAsync(
+        string? search,
+        string? orderBy,
+        int offset,
+        int limit
+    )
+    {
+        await using var ctx = await DbContextFactory.CreateDbContextAsync();
+        var query = ctx.Set<T>().AsQueryable();
+
+        if (!string.IsNullOrWhiteSpace(search))
+        {
+            query = ApplySearch(query, search);
+        }
+
+        var total = await query.CountAsync();
+
+        query = ApplySorting(query, orderBy);
+
+        var items = await query.Skip(offset).Take(limit).ToListAsync();
+
+        return new PagedResult<T>(items, total);
+    }
+
+    /// <summary>
+    /// Applies free-text search filtering. Subclasses override to define which fields are
+    /// searchable for their entity. The default returns the query unchanged (no search).
+    /// </summary>
+    protected virtual IQueryable<T> ApplySearch(IQueryable<T> query, string search) => query;
+
+    /// <summary>
+    /// Returns the sort selector for a given field name. Subclasses override to define which
+    /// fields are sortable. Returns <c>null</c> for unrecognised fields (they are skipped).
+    /// </summary>
+    protected virtual Expression<Func<T, object?>>? GetSortSelector(string fieldName) => null;
+
+    /// <summary>
+    /// Returns the default sort applied when no <c>orderBy</c> is specified. Defaults to
+    /// ascending by Id; subclasses may override.
+    /// </summary>
+    protected virtual IOrderedQueryable<T> ApplyDefaultSort(IQueryable<T> query) =>
+        query.OrderBy(e => e.Id);
+
+    private IQueryable<T> ApplySorting(IQueryable<T> query, string? orderBy)
+    {
+        if (string.IsNullOrWhiteSpace(orderBy))
+        {
+            return ApplyDefaultSort(query);
+        }
+
+        var fields = orderBy.Split(
+            ',',
+            StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries
+        );
+        IOrderedQueryable<T>? orderedQuery = null;
+
+        foreach (var field in fields)
+        {
+            var descending = field.StartsWith('-');
+            var fieldName = descending ? field[1..] : field;
+
+            var selector = GetSortSelector(fieldName);
+            if (selector is null)
+            {
+                continue;
+            }
+
+            if (orderedQuery is null)
+            {
+                orderedQuery = descending
+                    ? query.OrderByDescending(selector)
+                    : query.OrderBy(selector);
+            }
+            else
+            {
+                orderedQuery = descending
+                    ? orderedQuery.ThenByDescending(selector)
+                    : orderedQuery.ThenBy(selector);
+            }
+        }
+
+        return orderedQuery ?? ApplyDefaultSort(query);
     }
 }

--- a/src/WebApi/Common/PagedResponse.cs
+++ b/src/WebApi/Common/PagedResponse.cs
@@ -1,0 +1,11 @@
+namespace WebApiTemplate.WebApi.Common;
+
+/// <summary>
+/// API envelope for a page of results: the items plus paging metadata.
+/// </summary>
+/// <typeparam name="T">The item type.</typeparam>
+/// <param name="Items">The page of items.</param>
+/// <param name="Total">The total number of matching rows.</param>
+/// <param name="Offset">The zero-based offset of this page.</param>
+/// <param name="Limit">The requested page size.</param>
+public sealed record PagedResponse<T>(IReadOnlyList<T> Items, int Total, int Offset, int Limit);

--- a/src/WebApi/Customers/CustomersController.cs
+++ b/src/WebApi/Customers/CustomersController.cs
@@ -3,7 +3,9 @@ using Microsoft.AspNetCore.Mvc;
 using WebApiTemplate.Application.Customers.Commands;
 using WebApiTemplate.Application.Customers.Queries;
 using WebApiTemplate.Core;
+using WebApiTemplate.Core.Common;
 using WebApiTemplate.Core.Customers;
+using WebApiTemplate.WebApi.Common;
 using WebApiTemplate.WebApi.Customers.Requests;
 using WebApiTemplate.WebApi.Customers.Responses;
 
@@ -28,6 +30,30 @@ public sealed class CustomersController(IMediator mediator) : AppControllerBase(
             new CreateCustomerCommand(CreateCustomerRequest.ToDomainEntity())
         );
         return CreatedAtAction(nameof(GetById), new { id }, new CustomerCreatedResponse(id));
+    }
+
+    /// <summary>
+    /// Lists entities with search, sorting, and pagination.
+    /// </summary>
+    /// <param name="search">Free-text search term.</param>
+    /// <param name="orderBy">Comma-separated sort fields; prefix a field with '-' for descending.</param>
+    /// <param name="offset">Zero-based offset.</param>
+    /// <param name="limit">Maximum number of items to return.</param>
+    /// <returns>A 200 OK response with a page of entities and the total count.</returns>
+    [HttpGet]
+    [Route("")]
+    public async Task<ActionResult<PagedResponse<Customer>>> List(
+        [FromQuery] string? search,
+        [FromQuery] string? orderBy,
+        [FromQuery] int offset = 0,
+        [FromQuery] int limit = 25
+    )
+    {
+        var result = await _mediator.SendQuery<ListCustomersQuery, PagedResult<Customer>>(
+            new ListCustomersQuery(search, orderBy, offset, limit)
+        );
+
+        return Ok(new PagedResponse<Customer>(result.Items, result.Total, offset, limit));
     }
 
     /// <summary>

--- a/src/WebApi/Customers/Requests/CreateCustomerRequest.cs
+++ b/src/WebApi/Customers/Requests/CreateCustomerRequest.cs
@@ -11,5 +11,5 @@ public class CreateCustomerRequest
     /// Maps the request to a domain entity.
     /// </summary>
     /// <returns>The domain entity.</returns>
-    public static Customer ToDomainEntity() => new(null);
+    public static Customer ToDomainEntity() => new();
 }

--- a/src/WebApi/Customers/Requests/UpdateCustomerRequest.cs
+++ b/src/WebApi/Customers/Requests/UpdateCustomerRequest.cs
@@ -11,5 +11,5 @@ public class UpdateCustomerRequest
     /// Maps the request to a domain entity.
     /// </summary>
     /// <returns>The domain entity.</returns>
-    public static Customer ToDomainEntity() => new(null);
+    public static Customer ToDomainEntity() => new();
 }

--- a/tests/IntegrationTests/Customers/Controllers/DeleteTests.cs
+++ b/tests/IntegrationTests/Customers/Controllers/DeleteTests.cs
@@ -19,7 +19,7 @@ public class DeleteTests(AppWebApplicationFactory factory) : BaseTestClass(facto
             IDbContextFactory<AppDbContext>
         >();
         await using var context = await contextFactory.CreateDbContextAsync();
-        context.Customers.Add(new Core.Customers.Customer(id));
+        context.Customers.Add(new Core.Customers.Customer { Id = id });
         await context.SaveChangesAsync();
 
         using var client = _factory.CreateClient();

--- a/tests/IntegrationTests/Customers/Controllers/GetByIdTests.cs
+++ b/tests/IntegrationTests/Customers/Controllers/GetByIdTests.cs
@@ -19,7 +19,7 @@ public class GetByIdTests(AppWebApplicationFactory factory) : BaseTestClass(fact
             IDbContextFactory<AppDbContext>
         >();
         await using var context = await contextFactory.CreateDbContextAsync();
-        context.Customers.Add(new Core.Customers.Customer(id));
+        context.Customers.Add(new Core.Customers.Customer { Id = id });
         await context.SaveChangesAsync();
 
         using var client = _factory.CreateClient();

--- a/tests/IntegrationTests/Customers/Controllers/ListTests.cs
+++ b/tests/IntegrationTests/Customers/Controllers/ListTests.cs
@@ -1,0 +1,38 @@
+using System.Net;
+using AwesomeAssertions;
+using Microsoft.EntityFrameworkCore;
+using WebApiTemplate.Core.Customers;
+using WebApiTemplate.Infrastructure.Persistence;
+using WebApiTemplate.WebApi.Common;
+using Xunit;
+
+namespace WebApiTemplate.IntegrationTests.Customers.Controllers;
+
+public class ListTests(AppWebApplicationFactory factory) : BaseTestClass(factory)
+{
+    [Fact]
+    public async Task ReturnsPagedResult()
+    {
+        await _factory.ResetDatabase();
+
+        await using (var scope = _factory.CreateScope())
+        {
+            var contextFactory = scope.ServiceProvider.GetRequiredService<
+                IDbContextFactory<AppDbContext>
+            >();
+            await using var context = await contextFactory.CreateDbContextAsync();
+            context.Customers.AddRange(new Customer(), new Customer(), new Customer());
+            await context.SaveChangesAsync();
+        }
+
+        using var client = _factory.CreateClient();
+        using var response = await client.GetAsync("/api/v1/customers?offset=0&limit=2&orderBy=id");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var page = await response.Content.ReadFromJsonAsync<PagedResponse<Customer>>();
+        page.Should().NotBeNull();
+        page!.Total.Should().Be(3);
+        page.Items.Should().HaveCount(2);
+    }
+}

--- a/tests/UnitTests/Customers/CreateCustomerCommandHandler/HandleTests.cs
+++ b/tests/UnitTests/Customers/CreateCustomerCommandHandler/HandleTests.cs
@@ -31,7 +31,7 @@ public class HandleTests
             mockUowFactory,
             mockWriteRepository
         );
-        var newEntity = new Customer(13452);
+        var newEntity = new Customer { Id = 13452 };
 
         // Act
         await sut.Handle(new CreateCustomerCommand(newEntity));

--- a/tests/UnitTests/Customers/GetCustomerByIdQueryHandler/HandleTests.cs
+++ b/tests/UnitTests/Customers/GetCustomerByIdQueryHandler/HandleTests.cs
@@ -12,7 +12,7 @@ public class HandleTests
     public async Task WithValidRequestShouldCallRepository()
     {
         // Arrange
-        var expected = new Customer(1);
+        var expected = new Customer { Id = 1 };
         var mock = Substitute.For<ICustomerReadRepository>();
         mock.GetById(default).ReturnsForAnyArgs(expected);
 


### PR DESCRIPTION
Migrates reads from Dapper.Contrib to EF Core and adds a paginated/sortable/searchable list capability. Follow-up to #14.

## Changes
- **Core:** `PagedResult<T>`; `IReadRepository<T>` gains `ListAsync(search, orderBy, offset, limit)` and an optional `IUnitOfWork` on `GetById` (tracked reads).
- **Infrastructure:** `ReadRepositoryBase<T>` is now EF-based (via `IDbContextFactory`) with `ApplySearch` / `GetSortSelector` / `ApplyDefaultSort` extension points; `CustomerReadRepository` maps the sortable `id` field. **Drops Dapper + Dapper.Contrib.**
- **API:** `GET /api/v1/customers` (`ListCustomersQuery` + handler + validator) returning a `PagedResponse<T>` envelope (`items`, `total`, `offset`, `limit`).
- **Domain:** `BaseEntity`/`Customer` converted from records to classes — mutable + EF-idiomatic (records' value-equality interferes with EF change tracking).

## Validation
Build green; unit + Testcontainers integration tests pass (incl. a new `ListTests`), validated with a temporary `InitialCreate` migration.

## Notes
- `Customer` only carries `Id` in the template, so `ApplySearch` is left as a documented no-op extension point and the only sortable field is `id`. Real entities add their fields in `CustomerReadRepository.GetSortSelector` + `ListCustomersQueryValidator`.
- Integration tests still need an initial EF migration to run in CI (the `dotnet test` step stays commented per the template's convention).