### PR TITLE
chore(deps): bump shared package versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,17 +8,17 @@
     <GlobalPackageReference Include="IDisposableAnalyzers" Version="4.0.8" />
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
     <PackageVersion Include="Npgsql.DependencyInjection" Version="10.0.3" />
     <PackageVersion Include="SimpleInjector" Version="5.5.2" />
     <PackageVersion Include="SimpleInjector.Integration.AspNetCore.Mvc" Version="5.5.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.2" />
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
     <PackageVersion Include="HumbleMediator" Version="1.1.1" />
     <PackageVersion Include="EFCore.NamingConventions" Version="10.0.1" />

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -10,9 +10,9 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />
     <PackageVersion Include="Respawn" Version="7.0.0" />
     <PackageVersion Include="Testcontainers" Version="4.12.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.12.0" />


### PR DESCRIPTION
## Summary

Bumps shared NuGet package versions to keep dependencies current and consistent across projects. Only packages already referenced here were updated.

### Main `Directory.Packages.props`
| Package | Before | After |
|---|---|---|
| Microsoft.EntityFrameworkCore.Design | 10.0.8 | 10.0.9 |
| Microsoft.EntityFrameworkCore | 10.0.8 | 10.0.9 |
| Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore | 10.0.8 | 10.0.9 |
| Microsoft.Extensions.Logging.Abstractions | 10.0.8 | 10.0.9 |
| Swashbuckle.AspNetCore | 10.2.0 | 10.2.2 |

### Tests `tests/Directory.Packages.props`
| Package | Before | After |
|---|---|---|
| Microsoft.AspNetCore.Mvc.Testing | 10.0.8 | 10.0.9 |
| Microsoft.EntityFrameworkCore.InMemory | 10.0.8 | 10.0.9 |
| Microsoft.EntityFrameworkCore.Relational | 10.0.8 | 10.0.9 |

## Notes
- Patch/minor bumps only; no API-breaking changes expected.
- Package layout left unchanged (`Relational` stays scoped to the tests props, where its only direct consumer lives).

## Testing
- `dotnet restore` succeeds for all projects.